### PR TITLE
Implement cascading document filters

### DIFF
--- a/lk-mart-angular/src/app/components/document-table/document-table.css
+++ b/lk-mart-angular/src/app/components/document-table/document-table.css
@@ -86,6 +86,13 @@
   color: #1890ff;
 }
 
+/* Ссылка на тип документа */
+.doc-type-link {
+  color: #1890ff;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
 /* Стили для ссылки подсистемы */
 .subsystem-link {
   color: #1890ff;
@@ -249,3 +256,4 @@
   white-space: normal;     /* разрешает перенос */
   word-break: break-word;  /* щадящий перенос */
 }
+

--- a/lk-mart-angular/src/app/components/document-table/document-table.html
+++ b/lk-mart-angular/src/app/components/document-table/document-table.html
@@ -110,7 +110,13 @@
               Тип документа
             </th>
             } @else {
-              <th>Тип документа</th>
+              <th
+                [nzFilters]="docTypeFiltersOptions"
+                [nzFilterMultiple]="true"
+                [nzFilterFn]="true"
+                (nzFilterChange)="onDocTypeFilter($event)">
+                Тип документа
+              </th>
             }
             @if (isColumnSortable('doc_state')) {
             <th
@@ -120,7 +126,13 @@
               Статус
             </th>
             } @else {
-              <th>Статус</th>
+              <th
+                [nzFilters]="docStateFiltersOptions"
+                [nzFilterMultiple]="true"
+                [nzFilterFn]="true"
+                (nzFilterChange)="onDocStateFilter($event)">
+                Статус
+              </th>
             }
             <th>Пользователи</th>
           </tr>
@@ -133,7 +145,11 @@
               <!-- Номер документа -->
               <td>
                 <nz-typography>
-                  <span nz-typography class="doc-num">{{ document.document.docNum }}</span>
+                  <span
+                    nz-typography
+                    class="doc-num"
+                    (click)="onDocNumClick(document, $event)"
+                  >{{ document.document.docNum }}</span>
                 </nz-typography>
               </td>
 
@@ -177,7 +193,11 @@
               <!-- Тип документа -->
               <td>
                 <nz-typography>
-                  <span nz-typography>{{ document.docTypeName }}</span>
+                  <span
+                    nz-typography
+                    class="doc-type-link"
+                    (click)="onDocTypeClick(document); $event.stopPropagation()"
+                  >{{ document.docTypeName }}</span>
                 </nz-typography>
               </td>
 

--- a/lk-mart-angular/src/app/components/document-table/document-table.ts
+++ b/lk-mart-angular/src/app/components/document-table/document-table.ts
@@ -72,9 +72,9 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
 
   // Доступные фильтры
   availableFilters: FilterOption[] = [];
-  subsystemFilterOptions:Array<{ text: string; value: string; byDefault?: boolean }> = [];
-  docTypeFiltersOptions = [];
-  docStateFiltersOptions = [];
+  subsystemFilterOptions: Array<{ text: string; value: string; byDefault?: boolean }> = [];
+  docTypeFiltersOptions: Array<{ text: string; value: string }> = [];
+  docStateFiltersOptions: Array<{ text: string; value: any }> = [];
   // список всех выбранных фильтров
   selectedOptions: SubsystemFilterItem[] = [];
   // Сортировка
@@ -306,6 +306,7 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
         this.selectedOptions = this.availableFilters
           .filter(elem => subsys === elem.subsystem)
           .map(elem => this.toSubsystemItem(elem));
+        this.updateDocTypeOptions(subsys);
       }
     }
 
@@ -342,14 +343,68 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
    * @param option
    */
   onSubsystemFilter(option: string | string[]) {
-    const opt = Array.isArray(option)
-      ? option
-      : [option];
+    const opt = Array.isArray(option) ? option : [option];
     this.selectedOptions = this.availableFilters
       .filter(elem => opt.includes(elem.subsystem))
       .map(elem => this.toSubsystemItem(elem));
 
+    this.updateDocTypeOptions(this.selectedOptions[0]?.subsystem || '');
+    this.docStateFiltersOptions = [];
+
     this.loadDocuments();
+  }
+
+  private updateDocTypeOptions(subsystem: string): void {
+    const sub = this.availableFilters.find(f => f.subsystem === subsystem);
+    this.docTypeFiltersOptions = sub
+      ? sub.docTypes.map(dt => ({ text: dt.docTypeName, value: dt.docTypeId }))
+      : [];
+  }
+
+  private updateDocStateOptions(subsystem: string, docTypeIds: string[]): void {
+    this.docStateFiltersOptions = [];
+    const sub = this.availableFilters.find(f => f.subsystem === subsystem);
+    if (!sub) { return; }
+    sub.docTypes.forEach(dt => {
+      if (docTypeIds.includes(dt.docTypeId)) {
+        dt.docStates.forEach(state => {
+          this.docStateFiltersOptions.push({
+            text: `${dt.docTypeName}: ${state}`,
+            value: { docTypeId: dt.docTypeId, state: state }
+          });
+        });
+      }
+    });
+  }
+
+  onDocTypeFilter(option: string | string[]) {
+    const docTypeIds = Array.isArray(option) ? option : [option];
+    if (this.selectedOptions.length === 0) { return; }
+    this.selectedOptions[0].docTypes = docTypeIds.map(id => ({ docTypeId: id, docState: [] }));
+    this.updateDocStateOptions(this.selectedOptions[0].subsystem, docTypeIds);
+    this.loadDocuments();
+  }
+
+  onDocStateFilter(option: any | any[]) {
+    const selected = Array.isArray(option) ? option : [option];
+    if (this.selectedOptions.length === 0) { return; }
+    const map: { [key: string]: string[] } = {};
+    selected.forEach((val: any) => {
+      const { docTypeId, state } = val;
+      if (!map[docTypeId]) { map[docTypeId] = []; }
+      map[docTypeId].push(state);
+    });
+    this.selectedOptions[0].docTypes = Object.keys(map).map(id => ({ docTypeId: id, docState: map[id] }));
+    this.loadDocuments();
+  }
+
+  onDocNumClick(document: Document, event: Event): void {
+    event.stopPropagation();
+    this.documentOpenService.openDocumentPostMessage(document);
+  }
+
+  onDocTypeClick(document: Document): void {
+    this.modalService.showInfoModal('Тип документа', document.docTypeName);
   }
 
   toSubsystemItem(opt: FilterOption): SubsystemFilterItem {
@@ -361,7 +416,9 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
 
   resetAllFilters(): void {
     // выбранные фильтры
-    this.subsystemFilterOptions = []
+    this.subsystemFilterOptions = [];
+    this.docTypeFiltersOptions = [];
+    this.docStateFiltersOptions = [];
     this.selectedOptions = [];
     // сбросить сортировку
     this.currentSort = [];
@@ -371,3 +428,4 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
     this.loadDocuments();
   }
 }
+

--- a/lk-mart-angular/src/app/services/document-open.ts
+++ b/lk-mart-angular/src/app/services/document-open.ts
@@ -68,6 +68,27 @@ export class DocumentOpenService {
   }
 
   /**
+   * Отправляет сообщение для открытия документа через postMessage
+   * @param document - документ для открытия
+   */
+  openDocumentPostMessage(document: Document): void {
+    if (document && document.docGUID) {
+      const target = window.opener || window.parent;
+      if (target) {
+        target.postMessage(
+          {
+            type: 'openDocument',
+            documentId: document.docGUID,
+            subsystem: document.subsystem,
+            docType: document.docTypeId
+          },
+          '*'
+        );
+      }
+    }
+  }
+
+  /**
    * Скачивает документ
    * @param document - документ для скачивания
    */
@@ -88,3 +109,4 @@ export class DocumentOpenService {
     }
   }
 }
+


### PR DESCRIPTION
## Summary
- support selecting subsystem, document type and state cascades
- use postMessage when clicking document numbers
- open placeholder modal when clicking document type name
- restyle document type links

## Testing
- `npm test` *(fails: Application bundle generation failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a759f1ef8832cb73ff74ecc34d86c