### PR TITLE
Implement cascading filters and postMessage actions

### DIFF
--- a/lk-mart-angular/src/app/components/document-table/document-table.css
+++ b/lk-mart-angular/src/app/components/document-table/document-table.css
@@ -15,6 +15,17 @@
   padding: 16px;
 }
 
+.filter-selects {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.filter-select {
+  min-width: 160px;
+}
+
 .scope-buttons {
   display: flex;
   justify-content: center;
@@ -95,6 +106,12 @@
 
 .subsystem-link:hover {
   color: #40a9ff;
+}
+
+.doc-type {
+  color: #1890ff;
+  cursor: pointer;
+  text-decoration: underline;
 }
 
 /* Стили для тегов статуса */

--- a/lk-mart-angular/src/app/components/document-table/document-table.html
+++ b/lk-mart-angular/src/app/components/document-table/document-table.html
@@ -15,7 +15,30 @@
         Документы организации
       </button>
     </div>
-    <div>
+    <div class="filter-selects">
+      <nz-select
+        class="filter-select"
+        nzPlaceHolder="Подсистема"
+        [nzOptions]="subsystemFilterOptions"
+        [(ngModel)]="selectedSubsystem"
+        (ngModelChange)="onSubsystemFilter($event)">
+      </nz-select>
+      <nz-select
+        class="filter-select"
+        nzMode="multiple"
+        nzPlaceHolder="Тип документа"
+        [nzOptions]="docTypeFiltersOptions"
+        [(ngModel)]="selectedDocTypes"
+        (ngModelChange)="onDocTypeFilter($event)">
+      </nz-select>
+      <nz-select
+        class="filter-select"
+        nzMode="multiple"
+        nzPlaceHolder="Статус"
+        [nzOptions]="docStateFiltersOptions"
+        [(ngModel)]="selectedDocStates"
+        (ngModelChange)="onDocStateFilter($event)">
+      </nz-select>
       <button nz-button nzType="default" (click)="resetAllFilters()">
         <span nz-icon nzType="close-circle"></span> Сбросить фильтры
       </button>
@@ -133,7 +156,7 @@
               <!-- Номер документа -->
               <td>
                 <nz-typography>
-                  <span nz-typography class="doc-num">{{ document.document.docNum }}</span>
+                  <span nz-typography class="doc-num" (click)="onOpenDocument(document)">{{ document.document.docNum }}</span>
                 </nz-typography>
               </td>
 
@@ -177,7 +200,7 @@
               <!-- Тип документа -->
               <td>
                 <nz-typography>
-                  <span nz-typography>{{ document.docTypeName }}</span>
+                  <span nz-typography class="doc-type" (click)="onDocTypeClick(document)">{{ document.docTypeName }}</span>
                 </nz-typography>
               </td>
 

--- a/lk-mart-angular/src/app/components/document-table/document-table.ts
+++ b/lk-mart-angular/src/app/components/document-table/document-table.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { NzTableModule } from 'ng-zorro-antd/table';
@@ -17,6 +17,8 @@ import { NzBadgeModule } from 'ng-zorro-antd/badge';
 import { NzAvatarModule } from 'ng-zorro-antd/avatar';
 import { NzDescriptionsModule } from 'ng-zorro-antd/descriptions';
 import { NzModalModule } from 'ng-zorro-antd/modal';
+import { NzSelectModule } from 'ng-zorro-antd/select';
+import { FormsModule } from '@angular/forms';
 import { NzMessageService } from 'ng-zorro-antd/message';
 import { NzNotificationService } from 'ng-zorro-antd/notification';
 import {
@@ -32,7 +34,6 @@ import { DocumentListService } from '../../services/document-list';
 import { DocumentOpenService } from '../../services/document-open';
 import { NavigationNodesService } from '../../services/navigation-nodes';
 import { ModalService } from '../../services/modal';
-import { PubsubService } from '../../services/pubsub';
 
 @Component({
   selector: 'app-document-table',
@@ -53,7 +54,9 @@ import { PubsubService } from '../../services/pubsub';
     NzBadgeModule,
     NzAvatarModule,
     NzDescriptionsModule,
-    NzModalModule
+    NzModalModule,
+    NzSelectModule,
+    FormsModule
   ],
   templateUrl: './document-table.html',
   styleUrl: './document-table.css'
@@ -72,9 +75,13 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
 
   // Доступные фильтры
   availableFilters: FilterOption[] = [];
-  subsystemFilterOptions:Array<{ text: string; value: string; byDefault?: boolean }> = [];
-  docTypeFiltersOptions = [];
-  docStateFiltersOptions = [];
+  subsystemFilterOptions:Array<{ label: string; value: string }> = [];
+  docTypeFiltersOptions: Array<{ label: string; value: string }> = [];
+  docStateFiltersOptions: Array<{ label: string; options: Array<{ label: string; value: string }> }> = [];
+  selectedSubsystem: string | null = null;
+  selectedDocTypes: string[] = [];
+  selectedStatesMap: { [key: string]: string[] } = {};
+  selectedDocStates: string[] = [];
   // список всех выбранных фильтров
   selectedOptions: SubsystemFilterItem[] = [];
   // Сортировка
@@ -93,7 +100,6 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
     private documentOpenService: DocumentOpenService,
     private navigationNodesService: NavigationNodesService,
     private modalService: ModalService,
-    private pubsubService: PubsubService,
     private message: NzMessageService,
     private notification: NzNotificationService
   ) {}
@@ -271,6 +277,14 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
       });
   }
 
+  onDocTypeClick(document: Document): void {
+    this.modalService.showInfoModal('Тип документа', document.docTypeName, 'info');
+  }
+
+  onOpenDocument(document: Document): void {
+    this.documentOpenService.openDocument(document);
+  }
+
   /**
    * Форматирует дату
    */
@@ -296,16 +310,13 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
       this.availableFilters = filters.filterOptions;
       // Выбор подсистем
       this.subsystemFilterOptions = filters.filterOptions.map((dt: FilterOption) => ({
-        text: dt.subsystemName,
-        value: dt.subsystem,
-        byDefault: this.subsystemFilterOptions.length === 1
-      })) as Array<{ text: string; value: string; byDefault?: boolean }>;
+        label: dt.subsystemName,
+        value: dt.subsystem
+      }));
       // У нас только одна подсистема и сразу выбираем её
       if (this.subsystemFilterOptions.length === 1) {
         const subsys = this.subsystemFilterOptions[0].value;
-        this.selectedOptions = this.availableFilters
-          .filter(elem => subsys === elem.subsystem)
-          .map(elem => this.toSubsystemItem(elem));
+        this.onSubsystemFilter(subsys);
       }
     }
 
@@ -341,27 +352,85 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
    * Выбор эл-та подсистемы
    * @param option
    */
-  onSubsystemFilter(option: string | string[]) {
-    const opt = Array.isArray(option)
-      ? option
-      : [option];
-    this.selectedOptions = this.availableFilters
-      .filter(elem => opt.includes(elem.subsystem))
-      .map(elem => this.toSubsystemItem(elem));
+  onSubsystemFilter(option: string) {
+    this.selectedSubsystem = option;
+    this.selectedDocTypes = [];
+    this.selectedStatesMap = {};
+    this.selectedDocStates = [];
 
+    const found = this.availableFilters.find(f => f.subsystem === option);
+    this.docTypeFiltersOptions = found ?
+      found.docTypes.map(dt => ({ label: dt.docTypeName, value: dt.docTypeId })) : [];
+    this.docStateFiltersOptions = [];
+
+    this.updateSelectedOptions();
     this.loadDocuments();
   }
 
-  toSubsystemItem(opt: FilterOption): SubsystemFilterItem {
-    return {
-      subsystem: opt.subsystem,
-      docTypes: []
-    };
+  onDocTypeFilter(values: string[]) {
+    this.selectedDocTypes = values || [];
+    this.selectedDocStates = [];
+    this.selectedStatesMap = this.selectedDocTypes.reduce((acc, id) => {
+      acc[id] = this.selectedStatesMap[id] || [];
+      return acc;
+    }, {} as { [key: string]: string[] });
+
+    this.buildDocStateOptions();
+    this.updateSelectedOptions();
+    this.loadDocuments();
+  }
+
+  onDocStateFilter(values: string[]) {
+    this.selectedDocStates = values || [];
+    this.selectedStatesMap = {};
+    for (const val of this.selectedDocStates) {
+      const [dt, state] = val.split('|');
+      if (!this.selectedStatesMap[dt]) {
+        this.selectedStatesMap[dt] = [];
+      }
+      this.selectedStatesMap[dt].push(state);
+    }
+    this.updateSelectedOptions();
+    this.loadDocuments();
+  }
+
+  private buildDocStateOptions(): void {
+    const found = this.availableFilters.find(f => f.subsystem === this.selectedSubsystem);
+    const result: any[] = [];
+    if (found) {
+      for (const dt of found.docTypes) {
+        if (this.selectedDocTypes.includes(dt.docTypeId)) {
+          result.push({
+            label: dt.docTypeName,
+            options: dt.docStates.map(s => ({ label: s, value: `${dt.docTypeId}|${s}` }))
+          });
+        }
+      }
+    }
+    this.docStateFiltersOptions = result;
+  }
+
+  private updateSelectedOptions(): void {
+    if (this.selectedSubsystem) {
+      const docTypes = this.selectedDocTypes.map(id => ({
+        docTypeId: id,
+        docState: this.selectedStatesMap[id] || []
+      }));
+      this.selectedOptions = [{ subsystem: this.selectedSubsystem, docTypes }];
+    } else {
+      this.selectedOptions = [];
+    }
   }
 
   resetAllFilters(): void {
     // выбранные фильтры
-    this.subsystemFilterOptions = []
+    this.subsystemFilterOptions = [];
+    this.docTypeFiltersOptions = [];
+    this.docStateFiltersOptions = [];
+    this.selectedSubsystem = null;
+    this.selectedDocTypes = [];
+    this.selectedDocStates = [];
+    this.selectedStatesMap = {};
     this.selectedOptions = [];
     // сбросить сортировку
     this.currentSort = [];

--- a/lk-mart-angular/src/app/services/document-open.ts
+++ b/lk-mart-angular/src/app/services/document-open.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { PubsubService } from './pubsub';
 import { Document } from '../models/types';
 
 @Injectable({
@@ -7,7 +6,7 @@ import { Document } from '../models/types';
 })
 export class DocumentOpenService {
 
-  constructor(private pubsubService: PubsubService) {}
+  constructor() {}
 
   /**
    * Открывает документ в новой вкладке
@@ -15,15 +14,11 @@ export class DocumentOpenService {
    */
   openDocument(document: Document): void {
     if (document && document.docGUID) {
-      // Отправляем событие о выборе документа
-      this.pubsubService.publishDocumentSelected(
-        document.docGUID, 
-        document.subsystem, 
-        'open'
-      );
-      
-      // Открываем документ в новой вкладке
-      window.open(`/api/documents/${document.docGUID}/view`, '_blank');
+      window.parent.postMessage({
+        type: 'openDocument',
+        documentId: document.docGUID,
+        subsystem: document.subsystem
+      }, '*');
     }
   }
 
@@ -33,15 +28,11 @@ export class DocumentOpenService {
    */
   openDocumentInModal(document: Document): void {
     if (document && document.docGUID) {
-      // Отправляем событие о выборе документа
-      this.pubsubService.publishDocumentSelected(
-        document.docGUID, 
-        document.subsystem, 
-        'modal'
-      );
-      
-      // Здесь можно добавить логику открытия модального окна
-      console.log('Открытие документа в модальном окне:', document);
+      window.parent.postMessage({
+        type: 'openDocumentModal',
+        documentId: document.docGUID,
+        subsystem: document.subsystem
+      }, '*');
     }
   }
 
@@ -51,19 +42,12 @@ export class DocumentOpenService {
    */
   openDocumentInIframe(document: Document): void {
     if (document && document.docGUID) {
-      // Отправляем событие о выборе документа
-      this.pubsubService.publishDocumentSelected(
-        document.docGUID, 
-        document.subsystem, 
-        'iframe'
-      );
-      
-      // Отправляем событие для открытия в iframe
-      this.pubsubService.publish('openDocumentIframe', {
+      window.parent.postMessage({
+        type: 'openDocumentIframe',
         documentId: document.docGUID,
-        documentName: document.subsystem,
+        subsystem: document.subsystem,
         url: `/api/documents/${document.docGUID}/view`
-      });
+      }, '*');
     }
   }
 
@@ -73,18 +57,12 @@ export class DocumentOpenService {
    */
   downloadDocument(document: Document): void {
     if (document && document.docGUID) {
-      // Отправляем событие о выборе документа
-      this.pubsubService.publishDocumentSelected(
-        document.docGUID, 
-        document.subsystem, 
-        'download'
-      );
-      
-      // Создаем ссылку для скачивания
-      const link = document['createElement']('a');
-      link.href = `/api/documents/${document.docGUID}/download`;
-      link.download = document.subsystem || `document-${document.docGUID}`;
-      link.click();
+      window.parent.postMessage({
+        type: 'downloadDocument',
+        documentId: document.docGUID,
+        subsystem: document.subsystem,
+        url: `/api/documents/${document.docGUID}/download`
+      }, '*');
     }
   }
 }


### PR DESCRIPTION
## Summary
- add standalone filter selects for subsystem, doc type and status
- cascade options from API and build filter state
- make doc number and doc type cells clickable
- send document actions via `postMessage`

## Testing
- `npm test` *(fails: Application bundle generation failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a759f1ef8832cb73ff74ecc34d86c