### PR TITLE
Implement cascading document filters

### DIFF
--- a/lk-mart-angular/src/app/components/document-table/document-table.css
+++ b/lk-mart-angular/src/app/components/document-table/document-table.css
@@ -7,8 +7,8 @@
 /* Стили для переключателей области */
 .scope-selector {
   margin-bottom: 20px;
-  background: linear-gradient(135deg, #1890ff 0%, #722ed1 100%);
-  border: none;
+  background: #f5f5f5;
+  border: 1px solid #d9d9d9;
 }
 
 .scope-selector ::ng-deep .ant-card-body {
@@ -17,19 +17,18 @@
 
 .scope-buttons {
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
+  width: 100%;
 }
 
 .scope-button {
   min-width: 180px;
   height: 40px;
   font-weight: 500;
-  transition: all 0.3s ease;
 }
 
 .scope-button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: none;
 }
 
 /* Стили для сообщения об ошибке */
@@ -84,6 +83,13 @@
 .doc-num {
   font-weight: 500;
   color: #1890ff;
+}
+
+/* Ссылка на тип документа */
+.doc-type-link {
+  color: #1890ff;
+  cursor: pointer;
+  text-decoration: underline;
 }
 
 /* Стили для ссылки подсистемы */
@@ -249,3 +255,4 @@
   white-space: normal;     /* разрешает перенос */
   word-break: break-word;  /* щадящий перенос */
 }
+

--- a/lk-mart-angular/src/app/components/document-table/document-table.html
+++ b/lk-mart-angular/src/app/components/document-table/document-table.html
@@ -103,6 +103,7 @@
                 [nzFilterFn]="true"
                 (nzFilterChange)="onSubsystemFilter($event)"
                 [nzFilterMultiple]="false"
+                [nzFilteredValue]="subsystemFilteredValue"
               >Подсистема</th>
             }
             <!--   Особенность ant.design ->> Sort: Use [nzSortOrder]
@@ -120,7 +121,8 @@
                   [nzFilters]="docTypeFiltersOptions"
                   [nzFilterMultiple]="true"
                   [nzFilterFn]="true"
-                  (nzFilterChange)="onDocTypeFilter($event)">
+                  (nzFilterChange)="onDocTypeFilter($event)"
+                  [nzFilteredValue]="docTypeFilteredValue">
                   Тип документа
                 </th>
               } @else {
@@ -140,7 +142,8 @@
                   [nzFilters]="docStateFiltersOptions"
                   [nzFilterMultiple]="true"
                   [nzFilterFn]="true"
-                  (nzFilterChange)="onDocStateFilter($event)">
+                  (nzFilterChange)="onDocStateFilter($event)"
+                  [nzFilteredValue]="docStateFilteredValue">
                   Статус
                 </th>
               } @else {

--- a/lk-mart-angular/src/app/components/document-table/document-table.html
+++ b/lk-mart-angular/src/app/components/document-table/document-table.html
@@ -1,25 +1,30 @@
 <div class="document-table-container">
   <!-- Заголовок с переключателями области -->
   <nz-card class="scope-selector">
-    <div class="scope-buttons">
-      <button
-        [class]="'ant-btn scope-button ' + (isScopeActive('USER') ? 'ant-btn-primary' : 'ant-btn-default')"
-        (click)="switchScope('USER')">
-        <span nz-icon nzType="user" nzTheme="outline"></span>
-        Мои документы
-      </button>
-      <button
-        [class]="'ant-btn scope-button ' + (isScopeActive('ORG') ? 'ant-btn-primary' : 'ant-btn-default')"
-        (click)="switchScope('ORG')">
-        <span nz-icon nzType="bank" nzTheme="outline"></span>
-        Документы организации
-      </button>
-    </div>
-    <div>
+    <nz-space nzAlign="center" nzSize="middle" class="scope-buttons">
+      <nz-button-group>
+        <button
+          nz-button
+          class="scope-button"
+          [nzType]="isScopeActive('USER') ? 'primary' : 'default'"
+          (click)="switchScope('USER')">
+          <span nz-icon nzType="user"></span>
+          Мои документы
+        </button>
+        <button
+          nz-button
+          class="scope-button"
+          [nzType]="isScopeActive('ORG') ? 'primary' : 'default'"
+          (click)="switchScope('ORG')">
+          <span nz-icon nzType="bank"></span>
+          Документы организации
+        </button>
+      </nz-button-group>
       <button nz-button nzType="default" (click)="resetAllFilters()">
-        <span nz-icon nzType="close-circle"></span> Сбросить фильтры
+        <span nz-icon nzType="close-circle"></span>
+        Сбросить фильтры
       </button>
-    </div>
+    </nz-space>
   </nz-card>
 
   <!-- Сообщение об ошибке -->
@@ -53,7 +58,7 @@
         class="document-table">
 
         <!-- Колонка: Номер документа -->
-        <thead>
+        <thead (nzSortOrderChange)="onSortChange($event)">
           <tr>
             <th
               nzColumnKey="doc_num"
@@ -110,7 +115,17 @@
               Тип документа
             </th>
             } @else {
-              <th>Тип документа</th>
+              @if (docTypeFiltersOptions.length > 0) {
+                <th
+                  [nzFilters]="docTypeFiltersOptions"
+                  [nzFilterMultiple]="true"
+                  [nzFilterFn]="true"
+                  (nzFilterChange)="onDocTypeFilter($event)">
+                  Тип документа
+                </th>
+              } @else {
+                <th>Тип документа</th>
+              }
             }
             @if (isColumnSortable('doc_state')) {
             <th
@@ -120,7 +135,17 @@
               Статус
             </th>
             } @else {
-              <th>Статус</th>
+              @if (docStateFiltersOptions.length > 0) {
+                <th
+                  [nzFilters]="docStateFiltersOptions"
+                  [nzFilterMultiple]="true"
+                  [nzFilterFn]="true"
+                  (nzFilterChange)="onDocStateFilter($event)">
+                  Статус
+                </th>
+              } @else {
+                <th>Статус</th>
+              }
             }
             <th>Пользователи</th>
           </tr>
@@ -133,7 +158,11 @@
               <!-- Номер документа -->
               <td>
                 <nz-typography>
-                  <span nz-typography class="doc-num">{{ document.document.docNum }}</span>
+                  <span
+                    nz-typography
+                    class="doc-num"
+                    (click)="onDocNumClick(document, $event)"
+                  >{{ document.document.docNum }}</span>
                 </nz-typography>
               </td>
 
@@ -177,7 +206,11 @@
               <!-- Тип документа -->
               <td>
                 <nz-typography>
-                  <span nz-typography>{{ document.docTypeName }}</span>
+                  <span
+                    nz-typography
+                    class="doc-type-link"
+                    (click)="onDocTypeClick(document); $event.stopPropagation()"
+                  >{{ document.docTypeName }}</span>
                 </nz-typography>
               </td>
 

--- a/lk-mart-angular/src/app/components/document-table/document-table.html
+++ b/lk-mart-angular/src/app/components/document-table/document-table.html
@@ -103,7 +103,7 @@
                 [nzFilterFn]="true"
                 (nzFilterChange)="onSubsystemFilter($event)"
                 [nzFilterMultiple]="false"
-                [nzFilteredValue]="subsystemFilteredValue"
+                [nzFilterValue]="subsystemFilteredValue"
               >Подсистема</th>
             }
             <!--   Особенность ant.design ->> Sort: Use [nzSortOrder]
@@ -122,7 +122,7 @@
                   [nzFilterMultiple]="true"
                   [nzFilterFn]="true"
                   (nzFilterChange)="onDocTypeFilter($event)"
-                  [nzFilteredValue]="docTypeFilteredValue">
+                  [nzFilterValue]="docTypeFilteredValue">
                   Тип документа
                 </th>
               } @else {
@@ -143,7 +143,7 @@
                   [nzFilterMultiple]="true"
                   [nzFilterFn]="true"
                   (nzFilterChange)="onDocStateFilter($event)"
-                  [nzFilteredValue]="docStateFilteredValue">
+                  [nzFilterValue]="docStateFilteredValue">
                   Статус
                 </th>
               } @else {

--- a/lk-mart-angular/src/app/components/document-table/document-table.ts
+++ b/lk-mart-angular/src/app/components/document-table/document-table.ts
@@ -74,7 +74,7 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
   availableFilters: FilterOption[] = [];
   subsystemFilterOptions: Array<{ text: string; value: string; byDefault?: boolean }> = [];
   docTypeFiltersOptions: Array<{ text: string; value: string }> = [];
-  docStateFiltersOptions: Array<{ text: string; value: any }> = [];
+  docStateFiltersOptions: Array<{ text: string; value: string }> = [];
   // список всех выбранных фильтров
   selectedOptions: SubsystemFilterItem[] = [];
   // Сортировка
@@ -84,6 +84,23 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
 
   // Состояние сортировки для каждой колонки
   sortState: { [key: string]: SortDirection } = {};
+
+  // Значения для отображения выбранных фильтров в таблице
+  get subsystemFilteredValue(): string[] {
+    return this.selectedOptions.map(opt => opt.subsystem);
+  }
+
+  get docTypeFilteredValue(): string[] {
+    return this.selectedOptions[0]?.docTypes?.map(dt => dt.docTypeId) || [];
+  }
+
+  get docStateFilteredValue(): string[] {
+    const values: string[] = [];
+    this.selectedOptions[0]?.docTypes?.forEach(dt => {
+      dt.docState?.forEach(state => values.push(`${dt.docTypeId}:${state}`));
+    });
+    return values;
+  }
 
   private subscriptions: Subscription[] = [];
 
@@ -315,9 +332,21 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
           this.updateDocStateOptions(subsys, docTypeIds);
         }
       } else {
-        // При наличии нескольких подсистем фильтры типов и статусов очищаем
-        this.docTypeFiltersOptions = [];
-        this.docStateFiltersOptions = [];
+        // При наличии нескольких подсистем
+        if (this.selectedOptions.length > 0) {
+          const subsys = this.selectedOptions[0].subsystem;
+          this.updateDocTypeOptions(subsys);
+          const docTypeIds = this.selectedOptions[0].docTypes?.map(dt => dt.docTypeId) || [];
+          if (docTypeIds.length > 0) {
+            this.updateDocStateOptions(subsys, docTypeIds);
+          } else {
+            this.docStateFiltersOptions = [];
+          }
+        } else {
+          // нет выбранной подсистемы - очищаем зависимые фильтры
+          this.docTypeFiltersOptions = [];
+          this.docStateFiltersOptions = [];
+        }
       }
     }
 
@@ -381,7 +410,7 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
         dt.docStates.forEach(state => {
           this.docStateFiltersOptions.push({
             text: `${dt.docTypeName}: ${state}`,
-            value: { docTypeId: dt.docTypeId, state: state }
+            value: `${dt.docTypeId}:${state}`
           });
         });
       }
@@ -396,12 +425,12 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
     this.loadDocuments();
   }
 
-  onDocStateFilter(option: any | any[]) {
+  onDocStateFilter(option: string | string[]) {
     const selected = Array.isArray(option) ? option : [option];
     if (this.selectedOptions.length === 0) { return; }
     const map: { [key: string]: string[] } = {};
-    selected.forEach((val: any) => {
-      const { docTypeId, state } = val;
+    selected.forEach(val => {
+      const [docTypeId, state] = val.split(':');
       if (!map[docTypeId]) { map[docTypeId] = []; }
       map[docTypeId].push(state);
     });

--- a/lk-mart-angular/src/app/components/document-table/document-table.ts
+++ b/lk-mart-angular/src/app/components/document-table/document-table.ts
@@ -72,9 +72,9 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
 
   // Доступные фильтры
   availableFilters: FilterOption[] = [];
-  subsystemFilterOptions:Array<{ text: string; value: string; byDefault?: boolean }> = [];
-  docTypeFiltersOptions = [];
-  docStateFiltersOptions = [];
+  subsystemFilterOptions: Array<{ text: string; value: string; byDefault?: boolean }> = [];
+  docTypeFiltersOptions: Array<{ text: string; value: string }> = [];
+  docStateFiltersOptions: Array<{ text: string; value: any }> = [];
   // список всех выбранных фильтров
   selectedOptions: SubsystemFilterItem[] = [];
   // Сортировка
@@ -306,6 +306,11 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
         this.selectedOptions = this.availableFilters
           .filter(elem => subsys === elem.subsystem)
           .map(elem => this.toSubsystemItem(elem));
+        this.updateDocTypeOptions(subsys);
+      } else {
+        // При наличии нескольких подсистем фильтры типов и статусов очищаем
+        this.docTypeFiltersOptions = [];
+        this.docStateFiltersOptions = [];
       }
     }
 
@@ -342,14 +347,68 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
    * @param option
    */
   onSubsystemFilter(option: string | string[]) {
-    const opt = Array.isArray(option)
-      ? option
-      : [option];
+    const opt = Array.isArray(option) ? option : [option];
     this.selectedOptions = this.availableFilters
       .filter(elem => opt.includes(elem.subsystem))
       .map(elem => this.toSubsystemItem(elem));
 
+    this.updateDocTypeOptions(this.selectedOptions[0]?.subsystem || '');
+    this.docStateFiltersOptions = [];
+
     this.loadDocuments();
+  }
+
+  private updateDocTypeOptions(subsystem: string): void {
+    const sub = this.availableFilters.find(f => f.subsystem === subsystem);
+    this.docTypeFiltersOptions = sub
+      ? sub.docTypes.map(dt => ({ text: dt.docTypeName, value: dt.docTypeId }))
+      : [];
+  }
+
+  private updateDocStateOptions(subsystem: string, docTypeIds: string[]): void {
+    this.docStateFiltersOptions = [];
+    const sub = this.availableFilters.find(f => f.subsystem === subsystem);
+    if (!sub) { return; }
+    sub.docTypes.forEach(dt => {
+      if (docTypeIds.includes(dt.docTypeId)) {
+        dt.docStates.forEach(state => {
+          this.docStateFiltersOptions.push({
+            text: `${dt.docTypeName}: ${state}`,
+            value: { docTypeId: dt.docTypeId, state: state }
+          });
+        });
+      }
+    });
+  }
+
+  onDocTypeFilter(option: string | string[]) {
+    const docTypeIds = Array.isArray(option) ? option : [option];
+    if (this.selectedOptions.length === 0) { return; }
+    this.selectedOptions[0].docTypes = docTypeIds.map(id => ({ docTypeId: id, docState: [] }));
+    this.updateDocStateOptions(this.selectedOptions[0].subsystem, docTypeIds);
+    this.loadDocuments();
+  }
+
+  onDocStateFilter(option: any | any[]) {
+    const selected = Array.isArray(option) ? option : [option];
+    if (this.selectedOptions.length === 0) { return; }
+    const map: { [key: string]: string[] } = {};
+    selected.forEach((val: any) => {
+      const { docTypeId, state } = val;
+      if (!map[docTypeId]) { map[docTypeId] = []; }
+      map[docTypeId].push(state);
+    });
+    this.selectedOptions[0].docTypes = Object.keys(map).map(id => ({ docTypeId: id, docState: map[id] }));
+    this.loadDocuments();
+  }
+
+  onDocNumClick(document: Document, event: Event): void {
+    event.stopPropagation();
+    this.documentOpenService.openDocumentPostMessage(document);
+  }
+
+  onDocTypeClick(document: Document): void {
+    this.modalService.showInfoModal('Тип документа', document.docTypeName);
   }
 
   toSubsystemItem(opt: FilterOption): SubsystemFilterItem {
@@ -361,7 +420,9 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
 
   resetAllFilters(): void {
     // выбранные фильтры
-    this.subsystemFilterOptions = []
+    this.subsystemFilterOptions = [];
+    this.docTypeFiltersOptions = [];
+    this.docStateFiltersOptions = [];
     this.selectedOptions = [];
     // сбросить сортировку
     this.currentSort = [];
@@ -371,3 +432,4 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
     this.loadDocuments();
   }
 }
+

--- a/lk-mart-angular/src/app/components/document-table/document-table.ts
+++ b/lk-mart-angular/src/app/components/document-table/document-table.ts
@@ -300,13 +300,20 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
         value: dt.subsystem,
         byDefault: this.subsystemFilterOptions.length === 1
       })) as Array<{ text: string; value: string; byDefault?: boolean }>;
-      // У нас только одна подсистема и сразу выбираем её
+      // Автовыбор подсистемы только при отсутствии пользовательского выбора
       if (this.subsystemFilterOptions.length === 1) {
         const subsys = this.subsystemFilterOptions[0].value;
-        this.selectedOptions = this.availableFilters
-          .filter(elem => subsys === elem.subsystem)
-          .map(elem => this.toSubsystemItem(elem));
+        if (this.selectedOptions.length === 0) {
+          this.selectedOptions = this.availableFilters
+            .filter(elem => subsys === elem.subsystem)
+            .map(elem => this.toSubsystemItem(elem));
+        }
         this.updateDocTypeOptions(subsys);
+        const docTypeIds =
+          this.selectedOptions[0]?.docTypes?.map(dt => dt.docTypeId) || [];
+        if (docTypeIds.length > 0) {
+          this.updateDocStateOptions(subsys, docTypeIds);
+        }
       } else {
         // При наличии нескольких подсистем фильтры типов и статусов очищаем
         this.docTypeFiltersOptions = [];

--- a/lk-mart-angular/src/app/services/document-open.ts
+++ b/lk-mart-angular/src/app/services/document-open.ts
@@ -68,6 +68,27 @@ export class DocumentOpenService {
   }
 
   /**
+   * Отправляет сообщение для открытия документа через postMessage
+   * @param document - документ для открытия
+   */
+  openDocumentPostMessage(document: Document): void {
+    if (document && document.docGUID) {
+      const target = window.opener || window.parent;
+      if (target) {
+        target.postMessage(
+          {
+            type: 'openDocument',
+            documentId: document.docGUID,
+            subsystem: document.subsystem,
+            docType: document.docTypeId
+          },
+          '*'
+        );
+      }
+    }
+  }
+
+  /**
    * Скачивает документ
    * @param document - документ для скачивания
    */
@@ -88,3 +109,4 @@ export class DocumentOpenService {
     }
   }
 }
+


### PR DESCRIPTION
## Summary
- refine filter logic when multiple subsystems are present
- show document type and status filters only after subsystem is chosen
- handle table sort change event
- restyle scope switcher buttons for a more corporate look

## Testing
- `npm test` *(fails: ng not found)*
- `npx ng test --watch=false` *(fails: Application bundle generation failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a759f1ef8832cb73ff74ecc34d86c