### PR TITLE
Implement cascading filter panel

### DIFF
--- a/lk-mart-angular/src/app/components/document-table/document-table.css
+++ b/lk-mart-angular/src/app/components/document-table/document-table.css
@@ -258,8 +258,10 @@
 
 /* Кастомные каскадные фильтры */
 .cascade-filter {
-  max-width: 240px;
+  width: 300px;
+  max-width: 300px;
   padding: 8px;
+  transition: width 0.2s ease;
 }
 
 .filter-select {
@@ -271,6 +273,11 @@
   max-height: 260px;
   overflow: auto;
   margin-bottom: 8px;
+}
+
+.state-collapse .ant-collapse-header {
+  padding: 4px 8px;
+  line-height: 24px;
 }
 
 .state-item {

--- a/lk-mart-angular/src/app/components/document-table/document-table.css
+++ b/lk-mart-angular/src/app/components/document-table/document-table.css
@@ -256,3 +256,31 @@
   word-break: break-word;  /* щадящий перенос */
 }
 
+/* Кастомные каскадные фильтры */
+.cascade-filter {
+  max-width: 240px;
+  padding: 8px;
+}
+
+.filter-select {
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+.state-collapse {
+  max-height: 260px;
+  overflow: auto;
+  margin-bottom: 8px;
+}
+
+.state-item {
+  display: flex;
+  align-items: center;
+  margin-right: 8px;
+  margin-bottom: 4px;
+}
+
+.active-icon {
+  color: #1890ff;
+}
+

--- a/lk-mart-angular/src/app/components/document-table/document-table.css
+++ b/lk-mart-angular/src/app/components/document-table/document-table.css
@@ -289,6 +289,11 @@
   margin-bottom: 4px;
 }
 
+/* spacing between checkbox and text */
+.state-item > label {
+  margin-right: 4px;
+}
+
 .active-icon {
   color: #1890ff;
 }

--- a/lk-mart-angular/src/app/components/document-table/document-table.css
+++ b/lk-mart-angular/src/app/components/document-table/document-table.css
@@ -258,10 +258,11 @@
 
 /* Кастомные каскадные фильтры */
 .cascade-filter {
-  width: 300px;
-  max-width: 300px;
+  width: 320px;
+  max-width: 320px;
   padding: 8px;
-  transition: width 0.2s ease;
+  transition: width 0.2s ease, min-height 0.2s ease;
+  min-height: 220px;
 }
 
 .filter-select {
@@ -273,6 +274,7 @@
   max-height: 260px;
   overflow: auto;
   margin-bottom: 8px;
+  transition: max-height 0.2s ease;
 }
 
 .state-collapse .ant-collapse-header {
@@ -289,5 +291,11 @@
 
 .active-icon {
   color: #1890ff;
+}
+
+.filter-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }
 

--- a/lk-mart-angular/src/app/components/document-table/document-table.html
+++ b/lk-mart-angular/src/app/components/document-table/document-table.html
@@ -233,9 +233,9 @@
               </label>
             </nz-collapse-panel>
           </nz-collapse>
-          <div class="ant-table-filter-dropdown-btns">
-            <button nz-button nzType="link" nzSize="small" (click)="resetCascFilters()">Reset</button>
-            <button nz-button nzType="primary" nzSize="small" (click)="applyCascFilters()">Ok</button>
+          <div class="ant-table-filter-dropdown-btns filter-buttons">
+            <button nz-button nzSize="small" (click)="resetCascFilters()">Сбросить</button>
+            <button nz-button nzType="primary" nzSize="small" (click)="applyCascFilters()">Применить</button>
           </div>
         </div>
       </nz-dropdown-menu>

--- a/lk-mart-angular/src/app/components/document-table/document-table.html
+++ b/lk-mart-angular/src/app/components/document-table/document-table.html
@@ -95,63 +95,27 @@
               [nzSortOrder]="getSortDirection('account')">
               Счет
             </th>
-            @if (isColumnSortable('subsystem')) {
-              <th
-                nzColumnKey="subsystem"
-                [nzSortFn]="true"
-                [nzSortOrder]="getSortDirection('subsystem')">
-                Подсистема
-              </th>
-            } @else {
-              <th
-                [nzFilters]="subsystemFilterOptions"
-                [nzFilterFn]="true"
-                (nzFilterChange)="onSubsystemFilter($event)"
-                [nzFilterMultiple]="false"
-              >Подсистема</th>
-            }
+            <th nzCustomFilter>
+              Подсистема
+              <nz-filter-trigger
+                [(nzVisible)]="filterVisible"
+                [nzActive]="isCascFilterActive()"
+                [nzDropdownMenu]="cascMenu">
+                <span
+                  nz-tooltip
+                  [nzTooltipTitle]="isCascFilterActive() ? getFilterSummary() : 'Фильтр'">
+                  <nz-icon
+                    nzType="filter"
+                    nzTheme="fill"
+                    [ngClass]="{ 'active-icon': isCascFilterActive() }"></nz-icon>
+                </span>
+              </nz-filter-trigger>
+            </th>
+
             <!--   Особенность ant.design ->> Sort: Use [nzSortOrder]
             to make a column sorted by default, use [nzSortFn] to determine sort result, and [nzSortDirections] to define available sort methods       -->
-            @if (isColumnSortable('doc_type_name')) {
-            <th
-              nzSortKey="docTypeName"
-              [nzSortFn]="isColumnSortable('doc_type_name') ? true : false"
-              [nzSortOrder]="getSortDirection('docTypeName')">
-              Тип документа
-            </th>
-            } @else {
-              @if (docTypeFiltersOptions.length > 0) {
-                <th
-                  [nzFilters]="docTypeFiltersOptions"
-                  [nzFilterMultiple]="true"
-                  [nzFilterFn]="true"
-                  (nzFilterChange)="onDocTypeFilter($event)">
-                  Тип документа
-                </th>
-              } @else {
-                <th>Тип документа</th>
-              }
-            }
-            @if (isColumnSortable('doc_state')) {
-            <th
-              nzSortKey="docState"
-              [nzSortFn]="isColumnSortable('doc_state') ? true : false"
-              [nzSortOrder]="getSortDirection('docState')">
-              Статус
-            </th>
-            } @else {
-              @if (docStateFiltersOptions.length > 0) {
-                <th
-                  [nzFilters]="docStateFiltersOptions"
-                  [nzFilterMultiple]="true"
-                  [nzFilterFn]="true"
-                  (nzFilterChange)="onDocStateFilter($event)">
-                  Статус
-                </th>
-              } @else {
-                <th>Статус</th>
-              }
-            }
+            <th>Тип документа</th>
+            <th>Статус</th>
             <th>Пользователи</th>
           </tr>
         </thead>
@@ -244,6 +208,37 @@
           }
         </tbody>
       </nz-table>
+      <nz-dropdown-menu #cascMenu="nzDropdownMenu">
+        <div class="ant-table-filter-dropdown cascade-filter">
+          <nz-select
+            nzPlaceHolder="Подсистема"
+            [(ngModel)]="tempSubsystem"
+            (ngModelChange)="onTempSubsystemChange($event)"
+            class="filter-select">
+            <nz-option *ngFor="let o of subsystemFilterOptions" [nzValue]="o.value" [nzLabel]="o.text"></nz-option>
+          </nz-select>
+          <nz-select
+            nzMode="multiple"
+            nzPlaceHolder="Тип документа"
+            [(ngModel)]="tempDocTypeIds"
+            (ngModelChange)="onTempDocTypeChange($event)"
+            class="filter-select">
+            <nz-option *ngFor="let o of cascDocTypeOptions" [nzValue]="o.value" [nzLabel]="o.text"></nz-option>
+          </nz-select>
+          <nz-collapse nzBorderless class="state-collapse">
+            <nz-collapse-panel *ngFor="let group of cascDocStateOptions" [nzHeader]="group.docTypeName">
+              <label *ngFor="let st of group.states" class="state-item">
+                <label nz-checkbox [ngModel]="isTempStateSelected(group.docTypeId, st)" (ngModelChange)="toggleTempState(group.docTypeId, st, $event)"></label>
+                {{ st }}
+              </label>
+            </nz-collapse-panel>
+          </nz-collapse>
+          <div class="ant-table-filter-dropdown-btns">
+            <button nz-button nzType="link" nzSize="small" (click)="resetCascFilters()">Reset</button>
+            <button nz-button nzType="primary" nzSize="small" (click)="applyCascFilters()">Ok</button>
+          </div>
+        </div>
+      </nz-dropdown-menu>
     </nz-spin>
   </nz-card>
 </div>

--- a/lk-mart-angular/src/app/components/document-table/document-table.html
+++ b/lk-mart-angular/src/app/components/document-table/document-table.html
@@ -98,24 +98,51 @@
             <th nzCustomFilter>
               Подсистема
               <nz-filter-trigger
-                [(nzVisible)]="filterVisible"
-                [nzActive]="isCascFilterActive()"
+                [nzVisible]="activeColumn === 'subsystem' && filterVisible"
+                (nzVisibleChange)="onFilterVisibleChange($event, 'subsystem')"
+                [nzActive]="isSubsystemFilterActive()"
                 [nzDropdownMenu]="cascMenu">
                 <span
                   nz-tooltip
-                  [nzTooltipTitle]="isCascFilterActive() ? getFilterSummary() : 'Фильтр'">
+                  [nzTooltipTitle]="isSubsystemFilterActive() ? getFilterSummary() : 'Фильтр'">
                   <nz-icon
                     nzType="filter"
                     nzTheme="fill"
-                    [ngClass]="{ 'active-icon': isCascFilterActive() }"></nz-icon>
+                    [ngClass]="{ 'active-icon': isSubsystemFilterActive() }"></nz-icon>
                 </span>
               </nz-filter-trigger>
             </th>
 
             <!--   Особенность ant.design ->> Sort: Use [nzSortOrder]
             to make a column sorted by default, use [nzSortFn] to determine sort result, and [nzSortDirections] to define available sort methods       -->
-            <th>Тип документа</th>
-            <th>Статус</th>
+            <th nzCustomFilter>
+              Тип документа
+              <nz-filter-trigger
+                [nzVisible]="activeColumn === 'docType' && filterVisible"
+                (nzVisibleChange)="onFilterVisibleChange($event, 'docType')"
+                [nzActive]="isDocTypeFilterActive()"
+                [nzDropdownMenu]="cascMenu">
+                <span
+                  nz-tooltip
+                  [nzTooltipTitle]="isDocTypeFilterActive() ? getFilterSummary() : 'Фильтр'">
+                  <nz-icon nzType="filter" nzTheme="fill" [ngClass]="{ 'active-icon': isDocTypeFilterActive() }"></nz-icon>
+                </span>
+              </nz-filter-trigger>
+            </th>
+            <th nzCustomFilter>
+              Статус
+              <nz-filter-trigger
+                [nzVisible]="activeColumn === 'docState' && filterVisible"
+                (nzVisibleChange)="onFilterVisibleChange($event, 'docState')"
+                [nzActive]="isDocStateFilterActive()"
+                [nzDropdownMenu]="cascMenu">
+                <span
+                  nz-tooltip
+                  [nzTooltipTitle]="isDocStateFilterActive() ? getFilterSummary() : 'Фильтр'">
+                  <nz-icon nzType="filter" nzTheme="fill" [ngClass]="{ 'active-icon': isDocStateFilterActive() }"></nz-icon>
+                </span>
+              </nz-filter-trigger>
+            </th>
             <th>Пользователи</th>
           </tr>
         </thead>

--- a/lk-mart-angular/src/app/components/document-table/document-table.ts
+++ b/lk-mart-angular/src/app/components/document-table/document-table.ts
@@ -417,7 +417,8 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
     if (!sub) { return; }
     sub.docTypes.forEach(dt => {
       if (docTypeIds.includes(dt.docTypeId)) {
-        dt.docStates.forEach(state => {
+        const states = [...dt.docStates].sort((a, b) => a.localeCompare(b));
+        states.forEach(state => {
           this.docStateFiltersOptions.push({
             text: `${dt.docTypeName}: ${state}`,
             value: { docTypeId: dt.docTypeId, state: state }
@@ -603,7 +604,7 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
         this.cascDocStateOptions.push({
           docTypeId: dt.docTypeId,
           docTypeName: dt.docTypeName,
-          states: dt.docStates
+          states: [...dt.docStates].sort((a, b) => a.localeCompare(b))
         });
       }
     });

--- a/lk-mart-angular/src/app/components/document-table/document-table.ts
+++ b/lk-mart-angular/src/app/components/document-table/document-table.ts
@@ -89,6 +89,7 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
 
   // Cascading filter state
   filterVisible = false;
+  activeColumn: 'subsystem' | 'docType' | 'docState' = 'subsystem';
   tempSubsystem: string | null = null;
   tempDocTypeIds: string[] = [];
   tempDocStateMap: { [key: string]: string[] } = {};
@@ -494,6 +495,21 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
     return this.selectedOptions.length > 0;
   }
 
+  isSubsystemFilterActive(): boolean {
+    return this.selectedOptions.length > 0;
+  }
+
+  isDocTypeFilterActive(): boolean {
+    return this.selectedOptions.length > 0 &&
+      this.selectedOptions[0].docTypes &&
+      this.selectedOptions[0].docTypes.length > 0;
+  }
+
+  isDocStateFilterActive(): boolean {
+    return this.selectedOptions.length > 0 &&
+      this.selectedOptions[0].docTypes.some(dt => dt.docState && dt.docState.length > 0);
+  }
+
   getFilterSummary(): string {
     if (this.selectedOptions.length === 0) {
       return '';
@@ -514,10 +530,21 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
     return summary;
   }
 
+  onFilterVisibleChange(visible: boolean, column: 'subsystem' | 'docType' | 'docState'): void {
+    if (visible) {
+      this.activeColumn = column;
+      this.filterVisible = true;
+    } else {
+      this.filterVisible = false;
+    }
+  }
+
   onTempSubsystemChange(value: string | null): void {
     this.tempSubsystem = value;
     if (value) {
       this.updateCascDocTypeOptions(value);
+      this.activeColumn = 'docType';
+      this.filterVisible = true;
     } else {
       this.cascDocTypeOptions = [];
     }
@@ -536,6 +563,12 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
         delete this.tempDocStateMap[key];
       }
     });
+    if (values.length > 0) {
+      this.activeColumn = 'docState';
+      this.filterVisible = true;
+    } else {
+      this.activeColumn = 'docType';
+    }
   }
 
   toggleTempState(docTypeId: string, state: string, checked: boolean): void {
@@ -572,6 +605,7 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
     this.updateDocTypeOptions(this.tempSubsystem || '');
     this.updateDocStateOptions(this.tempSubsystem || '', this.tempDocTypeIds);
     this.filterVisible = false;
+    this.activeColumn = 'subsystem';
     this.pageIndex = 1;
     this.loadDocuments();
   }
@@ -584,6 +618,7 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
     this.cascDocStateOptions = [];
     this.selectedOptions = [];
     this.filterVisible = false;
+    this.activeColumn = 'subsystem';
     this.pageIndex = 1;
     this.loadDocuments();
   }

--- a/lk-mart-angular/src/app/components/document-table/document-table.ts
+++ b/lk-mart-angular/src/app/components/document-table/document-table.ts
@@ -17,6 +17,11 @@ import { NzBadgeModule } from 'ng-zorro-antd/badge';
 import { NzAvatarModule } from 'ng-zorro-antd/avatar';
 import { NzDescriptionsModule } from 'ng-zorro-antd/descriptions';
 import { NzModalModule } from 'ng-zorro-antd/modal';
+import { FormsModule } from '@angular/forms';
+import { NzDropDownModule } from 'ng-zorro-antd/dropdown';
+import { NzSelectModule } from 'ng-zorro-antd/select';
+import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
+import { NzCollapseModule } from 'ng-zorro-antd/collapse';
 import { NzMessageService } from 'ng-zorro-antd/message';
 import { NzNotificationService } from 'ng-zorro-antd/notification';
 import {
@@ -52,7 +57,12 @@ import { PubsubService } from '../../services/pubsub';
     NzBadgeModule,
     NzAvatarModule,
     NzDescriptionsModule,
-    NzModalModule
+    NzModalModule,
+    FormsModule,
+    NzDropDownModule,
+    NzSelectModule,
+    NzCheckboxModule,
+    NzCollapseModule
   ],
   templateUrl: './document-table.html',
   styleUrl: './document-table.css'
@@ -76,6 +86,14 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
   docStateFiltersOptions: Array<{ text: string; value: any }> = [];
   // список всех выбранных фильтров
   selectedOptions: SubsystemFilterItem[] = [];
+
+  // Cascading filter state
+  filterVisible = false;
+  tempSubsystem: string | null = null;
+  tempDocTypeIds: string[] = [];
+  tempDocStateMap: { [key: string]: string[] } = {};
+  cascDocTypeOptions: Array<{ text: string; value: string }> = [];
+  cascDocStateOptions: Array<{ docTypeId: string; docTypeName: string; states: string[] }> = [];
   // Сортировка
   sortableColumns: string[] = [];
   // Текущая сортировка
@@ -317,16 +335,21 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
             .filter(elem => subsys === elem.subsystem)
             .map(elem => this.toSubsystemItem(elem));
         }
+        this.tempSubsystem = subsys;
         this.updateDocTypeOptions(subsys);
+        this.updateCascDocTypeOptions(subsys);
         const docTypeIds =
           this.selectedOptions[0]?.docTypes?.map(dt => dt.docTypeId) || [];
         if (docTypeIds.length > 0) {
           this.updateDocStateOptions(subsys, docTypeIds);
+          this.updateCascDocStateOptions(subsys, docTypeIds);
         }
       } else {
         // При наличии нескольких подсистем фильтры типов и статусов очищаем
         this.docTypeFiltersOptions = [];
         this.docStateFiltersOptions = [];
+        this.cascDocTypeOptions = [];
+        this.cascDocStateOptions = [];
       }
     }
 
@@ -453,12 +476,146 @@ export class DocumentTableComponent implements OnInit, OnDestroy {
     this.docTypeFiltersOptions = [];
     this.docStateFiltersOptions = [];
     this.selectedOptions = [];
+    this.tempSubsystem = null;
+    this.tempDocTypeIds = [];
+    this.tempDocStateMap = {};
+    this.cascDocTypeOptions = [];
+    this.cascDocStateOptions = [];
     // сбросить сортировку
     this.currentSort = [];
     this.sortState = {};
     // И обновить данные
     this.pageIndex = 1;
     this.loadDocuments();
+  }
+
+  isCascFilterActive(): boolean {
+    return this.selectedOptions.length > 0;
+  }
+
+  getFilterSummary(): string {
+    if (this.selectedOptions.length === 0) {
+      return '';
+    }
+    const subItem = this.selectedOptions[0];
+    let summary = this.getSubsystemName(subItem.subsystem);
+    if (subItem.docTypes && subItem.docTypes.length > 0) {
+      const parts = subItem.docTypes.map(dt => {
+        const type = this.findDocType(subItem.subsystem, dt.docTypeId);
+        const name = type ? type.docTypeName : dt.docTypeId;
+        if (dt.docState && dt.docState.length > 0) {
+          return `${name}: ${dt.docState.join(',')}`;
+        }
+        return name;
+      });
+      summary += ' / ' + parts.join('; ');
+    }
+    return summary;
+  }
+
+  onTempSubsystemChange(value: string | null): void {
+    this.tempSubsystem = value;
+    if (value) {
+      this.updateCascDocTypeOptions(value);
+    } else {
+      this.cascDocTypeOptions = [];
+    }
+    this.tempDocTypeIds = [];
+    this.tempDocStateMap = {};
+    this.cascDocStateOptions = [];
+  }
+
+  onTempDocTypeChange(values: string[]): void {
+    this.tempDocTypeIds = values;
+    if (this.tempSubsystem) {
+      this.updateCascDocStateOptions(this.tempSubsystem, values);
+    }
+    Object.keys(this.tempDocStateMap).forEach(key => {
+      if (!values.includes(key)) {
+        delete this.tempDocStateMap[key];
+      }
+    });
+  }
+
+  toggleTempState(docTypeId: string, state: string, checked: boolean): void {
+    if (checked) {
+      if (!this.tempDocStateMap[docTypeId]) {
+        this.tempDocStateMap[docTypeId] = [];
+      }
+      if (!this.tempDocStateMap[docTypeId].includes(state)) {
+        this.tempDocStateMap[docTypeId].push(state);
+      }
+    } else {
+      if (this.tempDocStateMap[docTypeId]) {
+        this.tempDocStateMap[docTypeId] = this.tempDocStateMap[docTypeId].filter(s => s !== state);
+        if (this.tempDocStateMap[docTypeId].length === 0) {
+          delete this.tempDocStateMap[docTypeId];
+        }
+      }
+    }
+  }
+
+  isTempStateSelected(docTypeId: string, state: string): boolean {
+    return this.tempDocStateMap[docTypeId]?.includes(state) ?? false;
+  }
+
+  applyCascFilters(): void {
+    this.selectedOptions = [];
+    if (this.tempSubsystem) {
+      const item: SubsystemFilterItem = {
+        subsystem: this.tempSubsystem,
+        docTypes: this.tempDocTypeIds.map(id => ({ docTypeId: id, docState: this.tempDocStateMap[id] || [] }))
+      };
+      this.selectedOptions = [item];
+    }
+    this.updateDocTypeOptions(this.tempSubsystem || '');
+    this.updateDocStateOptions(this.tempSubsystem || '', this.tempDocTypeIds);
+    this.filterVisible = false;
+    this.pageIndex = 1;
+    this.loadDocuments();
+  }
+
+  resetCascFilters(): void {
+    this.tempSubsystem = null;
+    this.tempDocTypeIds = [];
+    this.tempDocStateMap = {};
+    this.cascDocTypeOptions = [];
+    this.cascDocStateOptions = [];
+    this.selectedOptions = [];
+    this.filterVisible = false;
+    this.pageIndex = 1;
+    this.loadDocuments();
+  }
+
+  private updateCascDocTypeOptions(subsystem: string): void {
+    const sub = this.availableFilters.find(f => f.subsystem === subsystem);
+    this.cascDocTypeOptions = sub ? sub.docTypes.map(dt => ({ text: dt.docTypeName, value: dt.docTypeId })) : [];
+  }
+
+  private updateCascDocStateOptions(subsystem: string, docTypeIds: string[]): void {
+    this.cascDocStateOptions = [];
+    const sub = this.availableFilters.find(f => f.subsystem === subsystem);
+    if (!sub) {
+      return;
+    }
+    sub.docTypes.forEach(dt => {
+      if (docTypeIds.includes(dt.docTypeId)) {
+        this.cascDocStateOptions.push({
+          docTypeId: dt.docTypeId,
+          docTypeName: dt.docTypeName,
+          states: dt.docStates
+        });
+      }
+    });
+  }
+
+  private getSubsystemName(subsystem: string): string {
+    const sub = this.availableFilters.find(f => f.subsystem === subsystem);
+    return sub ? sub.subsystemName : subsystem;
+  }
+
+  private findDocType(subsystem: string, docTypeId: string) {
+    return this.availableFilters.find(f => f.subsystem === subsystem)?.docTypes.find(dt => dt.docTypeId === docTypeId);
   }
 }
 


### PR DESCRIPTION
## Summary
- add dropdown, select and checkbox modules to document table
- implement cascading filter logic with state management
- add custom filter dropdown in the document table header
- show selected filter summary and styling for new filter panel
- refine cascade filter UI with tooltips, padding and collapsible state groups

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b4b8f95c4832ca14a6306b656078f